### PR TITLE
chore: Bump actions/cache to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
                 with:
                     php-version: 7.4
                     coverage: none
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v4
                 with:
                     path: vendor
                     key: php-7.4-vendor-${{ hashFiles('**/composer.json') }}
@@ -44,7 +44,7 @@ jobs:
                 with:
                     php-version: ${{ matrix.php-version }}
                     ini-values: date.timezone=Europe/Amsterdam, assert.exception=1, zend.assertions=1
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v4
                 with:
                     path: vendor
                     key: php-${{ matrix.php-version }}-vendor-${{ hashFiles('**/composer.json') }}

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    totallyTyped="true"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
### Summary 🌟
`actions/cache` v1 and v2 are [deprecated](https://github.com/actions/cache/discussions/1510). v3 and v4 are completely backwards compatible and we can just bump the versions. Passing CI is testing this change.